### PR TITLE
Avoid file system hit on autoloading classes

### DIFF
--- a/justfile
+++ b/justfile
@@ -178,7 +178,7 @@ deploy:
 	cd app && yarn build
 	cd app && find dist -type f -atime +30 -delete
 	cd app && find dist -type d -empty -delete
-	cd api && composer --no-interaction install --prefer-dist --no-dev --optimize-autoloader
+	cd api && composer --no-interaction install --prefer-dist --no-dev --optimize-autoloader --classmap-authoritative
 	cd api && composer dump-env prod
 	systemctl restart php-fpm@www.service
 	cd api && bin/console doctrine:migrations:sync-metadata-storage --no-interaction


### PR DESCRIPTION
This tells the autoloader not to search on file system for classes not listed in the classmap. This may improve performance marginally.

See https://getcomposer.org/doc/articles/autoloader-optimization.md#optimization-level-2-a-authoritative-class-maps